### PR TITLE
refactor: extract user profile operations from AuthProvider

### DIFF
--- a/app/components/UsernameForm.tsx
+++ b/app/components/UsernameForm.tsx
@@ -211,7 +211,7 @@ export default function UsernameForm({ isFirstTime = false, onComplete }: Userna
                 : 'bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2'
             }`}
           >
-            {isSubmitting ? 'Saving…' : isFirstTime ? 'Create Username' : 'Update Username'}
+            {isSubmitting ? 'Verifying & Saving…' : isFirstTime ? 'Create Username' : 'Sign & Update Username'}
           </button>
           
           {isFirstTime && (
@@ -228,9 +228,9 @@ export default function UsernameForm({ isFirstTime = false, onComplete }: Userna
       </form>
 
       {!isFirstTime && (
-        <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-md">
-          <p className="text-sm text-yellow-800">
-            <strong>Note:</strong> In the future, you&apos;ll need to sign a transaction to verify wallet ownership before changing your username.
+        <div className="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-md">
+          <p className="text-sm text-blue-800">
+            <strong>Security:</strong> You&apos;ll be asked to sign a message with your wallet to verify ownership before changing your username.
           </p>
         </div>
       )}

--- a/app/components/UsernameForm.tsx
+++ b/app/components/UsernameForm.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { useAuth } from '@/app/providers/AuthProvider';
+import { useUserProfile } from '@/hooks/useUserProfile';
 
 interface UsernameFormProps {
   isFirstTime?: boolean;
@@ -15,7 +16,8 @@ export default function UsernameForm({ isFirstTime = false, onComplete }: Userna
   const [validationError, setValidationError] = useState('');
   const [isAvailable, setIsAvailable] = useState<boolean | null>(null);
 
-  const { updateUsername, checkUsernameAvailable, user, error } = useAuth();
+  const { user } = useAuth();
+  const { updateUsername, checkUsernameAvailable, error: profileError, isUpdating } = useUserProfile();
 
   // Validate username format
   const validateUsername = (value: string): string => {
@@ -111,14 +113,11 @@ export default function UsernameForm({ isFirstTime = false, onComplete }: Userna
       return;
     }
 
-    setIsSubmitting(true);
     try {
       await updateUsername(trimmed);
       onComplete?.();
     } catch (err) {
-      // Error is handled by the auth context
-    } finally {
-      setIsSubmitting(false);
+      // Error is handled by the useUserProfile hook
     }
   };
 
@@ -196,29 +195,29 @@ export default function UsernameForm({ isFirstTime = false, onComplete }: Userna
             <p className="text-green-600 text-sm mt-1">Username is available!</p>
           )}
           
-          {error && (
-            <p className="text-red-600 text-sm mt-1">{error}</p>
+          {profileError && (
+            <p className="text-red-600 text-sm mt-1">{profileError}</p>
           )}
         </div>
 
         <div className="flex gap-3">
           <button
             type="submit"
-            disabled={isSubmitting || !!validationError || isAvailable !== true}
+            disabled={isUpdating || !!validationError || isAvailable !== true}
             className={`flex-1 py-2 px-4 rounded-md font-medium transition-colors ${
-              isSubmitting || !!validationError || isAvailable !== true
+              isUpdating || !!validationError || isAvailable !== true
                 ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
                 : 'bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2'
             }`}
           >
-            {isSubmitting ? 'Verifying & Saving…' : isFirstTime ? 'Create Username' : 'Sign & Update Username'}
+            {isUpdating ? 'Verifying & Saving…' : isFirstTime ? 'Create Username' : 'Sign & Update Username'}
           </button>
           
           {isFirstTime && (
             <button
               type="button"
               onClick={handleSkip}
-              disabled={isSubmitting}
+              disabled={isUpdating}
               className="px-4 py-2 text-gray-600 hover:text-gray-800 font-medium transition-colors"
             >
               Skip for now

--- a/app/providers/AuthProvider.tsx
+++ b/app/providers/AuthProvider.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext, useEffect, useState, ReactNode } from
 import { useWallet } from '@solana/wallet-adapter-react';
 import { createSupabaseBrowserClient, User } from '@/lib/supabase';
 import { AuthError } from '@supabase/supabase-js';
-import { useWalletVerification } from '@/hooks/useWalletVerification';
+import { useUserOperations } from '@/hooks/useUserOperations';
 
 interface AuthContextType {
   user: User | null;
@@ -27,7 +27,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { publicKey, connected } = useWallet();
-  const { verifyUsernameChange } = useWalletVerification();
+  const { verifyUsernameChange } = useUserOperations();
   const supabase = createSupabaseBrowserClient();
 
   // Check if user exists or create new user

--- a/app/providers/AuthProvider.tsx
+++ b/app/providers/AuthProvider.tsx
@@ -12,8 +12,7 @@ interface AuthContextType {
   error: string | null;
   signInWithWallet: () => Promise<void>;
   signOut: () => Promise<void>;
-  updateUsername: (username: string) => Promise<void>;
-  checkUsernameAvailable: (username: string) => Promise<boolean>;
+  setUser: (user: User | null) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -27,7 +26,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { publicKey, connected } = useWallet();
-  const { verifyUsernameChange } = useUserOperations();
   const supabase = createSupabaseBrowserClient();
 
   // Check if user exists or create new user
@@ -101,79 +99,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   };
 
-  // Update username with wallet signature verification
-  const updateUsername = async (username: string) => {
-    if (!user) {
-      throw new Error('User not authenticated');
-    }
-
-    try {
-      setError(null);
-      
-      // Trim and validate username
-      const trimmedUsername = username.trim();
-      if (!trimmedUsername) {
-        throw new Error('Username cannot be empty');
-      }
-
-      // Check if this is already their current username
-      if (user.username && user.username.toLowerCase() === trimmedUsername.toLowerCase()) {
-        throw new Error('This is already your current username');
-      }
-
-      // Check if username is available
-      const isAvailable = await checkUsernameAvailable(trimmedUsername);
-      if (!isAvailable) {
-        throw new Error('Username is already taken');
-      }
-
-      // Verify wallet ownership with signature
-      await verifyUsernameChange(trimmedUsername);
-
-      // Update username in database
-      const { data: updatedUser, error: updateError } = await supabase
-        .from('users')
-        .update({ username: trimmedUsername })
-        .eq('id', user.id)
-        .select()
-        .single();
-
-      if (updateError) {
-        throw updateError;
-      }
-
-      setUser(updatedUser);
-    } catch (err) {
-      console.error('Error updating username:', err);
-      const errorMessage = err instanceof Error ? err.message : 'Failed to update username';
-      setError(errorMessage);
-      throw new Error(errorMessage);
-    }
-  };
-
-  // Check if username is available
-  const checkUsernameAvailable = async (username: string): Promise<boolean> => {
-    try {
-      const trimmedUsername = username.trim();
-      if (!trimmedUsername) return false;
-
-      const { data, error } = await supabase
-        .from('users')
-        .select('id')
-        .ilike('username', trimmedUsername)
-        .neq('id', user?.id || '');
-
-      if (error) {
-        console.error('Error checking username availability:', error);
-        return false;
-      }
-
-      return data.length === 0;
-    } catch (err) {
-      console.error('Error checking username availability:', err);
-      return false;
-    }
-  };
 
   // Auto-authenticate when wallet connects/disconnects or switches
   useEffect(() => {
@@ -210,8 +135,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     error,
     signInWithWallet,
     signOut,
-    updateUsername,
-    checkUsernameAvailable,
+    setUser,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/hooks/useUserOperations.ts
+++ b/hooks/useUserOperations.ts
@@ -1,0 +1,29 @@
+import { useWalletVerification } from './useWalletVerification';
+import { WalletVerificationService } from '@/lib/walletVerification';
+
+export function useUserOperations() {
+  const { verifyOwnership, isWalletReady, walletAddress } = useWalletVerification();
+
+  /**
+   * Verify ownership for username changes
+   * @param newUsername - The new username
+   * @returns Promise<Uint8Array> - The signature
+   */
+  const verifyUsernameChange = async (newUsername: string): Promise<Uint8Array> => {
+    if (!walletAddress) {
+      throw new Error('Wallet not connected');
+    }
+
+    const options = WalletVerificationService.createUsernameChangeMessage(
+      newUsername,
+      walletAddress
+    );
+
+    return verifyOwnership(options);
+  };
+
+  return {
+    verifyUsernameChange,
+    isWalletReady,
+  };
+}

--- a/hooks/useUserProfile.ts
+++ b/hooks/useUserProfile.ts
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useAuth } from '@/app/providers/AuthProvider';
+import { useUserOperations } from './useUserOperations';
+import { createSupabaseBrowserClient } from '@/lib/supabase';
+
+export function useUserProfile() {
+  const [error, setError] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const { user, setUser } = useAuth();
+  const { verifyUsernameChange } = useUserOperations();
+  const supabase = createSupabaseBrowserClient();
+
+  /**
+   * Check if username is available
+   * @param username - Username to check
+   * @returns Promise<boolean> - True if available
+   */
+  const checkUsernameAvailable = async (username: string): Promise<boolean> => {
+    try {
+      const trimmedUsername = username.trim();
+      if (!trimmedUsername) return false;
+
+      const { data, error } = await supabase
+        .from('users')
+        .select('id')
+        .ilike('username', trimmedUsername)
+        .neq('id', user?.id || '');
+
+      if (error) {
+        console.error('Error checking username availability:', error);
+        return false;
+      }
+
+      return data.length === 0;
+    } catch (err) {
+      console.error('Error checking username availability:', err);
+      return false;
+    }
+  };
+
+  /**
+   * Update username with wallet signature verification
+   * @param username - New username
+   */
+  const updateUsername = async (username: string): Promise<void> => {
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
+
+    try {
+      setError(null);
+      setIsUpdating(true);
+      
+      // Trim and validate username
+      const trimmedUsername = username.trim();
+      if (!trimmedUsername) {
+        throw new Error('Username cannot be empty');
+      }
+
+      // Check if this is already their current username
+      if (user.username && user.username.toLowerCase() === trimmedUsername.toLowerCase()) {
+        throw new Error('This is already your current username');
+      }
+
+      // Check if username is available
+      const isAvailable = await checkUsernameAvailable(trimmedUsername);
+      if (!isAvailable) {
+        throw new Error('Username is already taken');
+      }
+
+      // Verify wallet ownership with signature
+      await verifyUsernameChange(trimmedUsername);
+
+      // Update username in database
+      const { data: updatedUser, error: updateError } = await supabase
+        .from('users')
+        .update({ username: trimmedUsername })
+        .eq('id', user.id)
+        .select()
+        .single();
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      // Update user in auth context
+      setUser(updatedUser);
+    } catch (err) {
+      console.error('Error updating username:', err);
+      const errorMessage = err instanceof Error ? err.message : 'Failed to update username';
+      setError(errorMessage);
+      throw new Error(errorMessage);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return {
+    updateUsername,
+    checkUsernameAvailable,
+    isUpdating,
+    error,
+  };
+}

--- a/hooks/useWalletVerification.ts
+++ b/hooks/useWalletVerification.ts
@@ -1,0 +1,58 @@
+import { useWallet } from '@solana/wallet-adapter-react';
+import { WalletVerificationService, VerificationOptions } from '@/lib/walletVerification';
+
+export function useWalletVerification() {
+  const { publicKey, connected, signMessage } = useWallet();
+
+  /**
+   * Verify wallet ownership with signature
+   * @param options - Verification options
+   * @returns Promise<Uint8Array> - The signature
+   */
+  const verifyOwnership = async (options: VerificationOptions): Promise<Uint8Array> => {
+    if (!publicKey || !connected || !signMessage) {
+      throw new Error('Wallet not connected or does not support signing');
+    }
+
+    return WalletVerificationService.verifyOwnership(
+      { publicKey, signMessage },
+      options
+    );
+  };
+
+  /**
+   * Verify ownership for username changes
+   * @param newUsername - The new username
+   * @returns Promise<Uint8Array> - The signature
+   */
+  const verifyUsernameChange = async (newUsername: string): Promise<Uint8Array> => {
+    if (!publicKey) {
+      throw new Error('Wallet not connected');
+    }
+
+    const options = WalletVerificationService.createUsernameChangeMessage(
+      newUsername,
+      publicKey.toBase58()
+    );
+
+    return verifyOwnership(options);
+  };
+
+  /**
+   * Verify ownership for team operations
+   * @param operation - The team operation
+   * @param teamName - The team name
+   * @returns Promise<Uint8Array> - The signature
+   */
+  const verifyTeamOperation = async (operation: string, teamName: string): Promise<Uint8Array> => {
+    const options = WalletVerificationService.createTeamOperationMessage(operation, teamName);
+    return verifyOwnership(options);
+  };
+
+  return {
+    verifyOwnership,
+    verifyUsernameChange,
+    verifyTeamOperation,
+    isWalletReady: !!(publicKey && connected && signMessage),
+  };
+}

--- a/hooks/useWalletVerification.ts
+++ b/hooks/useWalletVerification.ts
@@ -20,39 +20,9 @@ export function useWalletVerification() {
     );
   };
 
-  /**
-   * Verify ownership for username changes
-   * @param newUsername - The new username
-   * @returns Promise<Uint8Array> - The signature
-   */
-  const verifyUsernameChange = async (newUsername: string): Promise<Uint8Array> => {
-    if (!publicKey) {
-      throw new Error('Wallet not connected');
-    }
-
-    const options = WalletVerificationService.createUsernameChangeMessage(
-      newUsername,
-      publicKey.toBase58()
-    );
-
-    return verifyOwnership(options);
-  };
-
-  /**
-   * Verify ownership for team operations
-   * @param operation - The team operation
-   * @param teamName - The team name
-   * @returns Promise<Uint8Array> - The signature
-   */
-  const verifyTeamOperation = async (operation: string, teamName: string): Promise<Uint8Array> => {
-    const options = WalletVerificationService.createTeamOperationMessage(operation, teamName);
-    return verifyOwnership(options);
-  };
-
   return {
     verifyOwnership,
-    verifyUsernameChange,
-    verifyTeamOperation,
     isWalletReady: !!(publicKey && connected && signMessage),
+    walletAddress: publicKey?.toBase58() || null,
   };
 }

--- a/lib/walletVerification.ts
+++ b/lib/walletVerification.ts
@@ -1,0 +1,85 @@
+import { PublicKey } from '@solana/web3.js';
+
+export interface WalletSigner {
+  publicKey: PublicKey;
+  signMessage: (message: Uint8Array) => Promise<Uint8Array>;
+}
+
+export interface VerificationOptions {
+  action: string;
+  details?: string;
+  timestamp?: number;
+}
+
+export class WalletVerificationService {
+  /**
+   * Verify wallet ownership by requiring a signature
+   * @param signer - Wallet signer with publicKey and signMessage function
+   * @param options - Verification options including action description
+   * @returns Promise<Uint8Array> - The signature bytes
+   * @throws Error if verification fails
+   */
+  static async verifyOwnership(
+    signer: WalletSigner,
+    options: VerificationOptions
+  ): Promise<Uint8Array> {
+    const { publicKey, signMessage } = signer;
+    const { action, details, timestamp = Date.now() } = options;
+
+    if (!publicKey || !signMessage) {
+      throw new Error('Wallet not connected or does not support signing');
+    }
+
+    // Create message to sign for verification
+    let message = `Verify wallet ownership for: ${action}`;
+    
+    if (details) {
+      message += `\n\nDetails: ${details}`;
+    }
+    
+    message += `\n\nWallet: ${publicKey.toBase58()}\nTimestamp: ${timestamp}`;
+    
+    const messageBytes = new TextEncoder().encode(message);
+
+    // Request wallet signature
+    let signature: Uint8Array;
+    try {
+      signature = await signMessage(messageBytes);
+    } catch (signError) {
+      throw new Error('Signature verification cancelled or failed');
+    }
+
+    // Verify the signature (basic verification that we got a signature)
+    if (!signature || signature.length === 0) {
+      throw new Error('Invalid signature received');
+    }
+
+    return signature;
+  }
+
+  /**
+   * Create a verification message for username changes
+   * @param newUsername - The new username being set
+   * @param walletAddress - The wallet address
+   * @returns Formatted message for signing
+   */
+  static createUsernameChangeMessage(newUsername: string, walletAddress: string): VerificationOptions {
+    return {
+      action: 'Change Username',
+      details: `New username: "${newUsername}"`,
+    };
+  }
+
+  /**
+   * Create a verification message for team operations
+   * @param operation - The team operation (create, join, leave, etc.)
+   * @param teamName - The team name
+   * @returns Formatted message for signing
+   */
+  static createTeamOperationMessage(operation: string, teamName: string): VerificationOptions {
+    return {
+      action: `Team ${operation}`,
+      details: `Team: "${teamName}"`,
+    };
+  }
+}

--- a/lib/walletVerification.ts
+++ b/lib/walletVerification.ts
@@ -70,16 +70,4 @@ export class WalletVerificationService {
     };
   }
 
-  /**
-   * Create a verification message for team operations
-   * @param operation - The team operation (create, join, leave, etc.)
-   * @param teamName - The team name
-   * @returns Formatted message for signing
-   */
-  static createTeamOperationMessage(operation: string, teamName: string): VerificationOptions {
-    return {
-      action: `Team ${operation}`,
-      details: `Team: "${teamName}"`,
-    };
-  }
 }


### PR DESCRIPTION
## description 

refactor: extract user profile operations from AuthProvider

Moved user profile management logic out of `AuthProvider` into dedicated hooks. AuthProvider was handling both authentication state and profile operations, which violates separation of concerns. Now AuthProvider focuses solely on authentication while profile operations are handled by specialized hooks.

## testing

functionality remains intact

- tried to change username and signed (changed username)
- tried to change username and didn't sign (didn't change username)
- used a new wallet and prompted to make username (I added one and signed and it worked)
- used a new wallet and prompted to make username (I didn't add one and later went back to add one it worked)

## deployment info

standard deployment 
no db changes required