### PR TITLE
feat: implement team slugs and dynamic team pages

### DIFF
--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -38,6 +38,14 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Validate team name doesn't contain hyphens or underscores (reserved for slug generation)
+    if (/[-_]/.test(trimmedTeamName)) {
+      return NextResponse.json(
+        { error: 'Team name cannot contain hyphens (-) or underscores (_)' },
+        { status: 400 }
+      )
+    }
+
     const supabase = createSupabaseBrowserClient()
 
     // Generate unique slug from team name

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -38,10 +38,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Validate team name doesn't contain hyphens or underscores (reserved for slug generation)
-    if (/[-_]/.test(trimmedTeamName)) {
+    // Validate team name contains only letters, numbers, and spaces
+    if (!/^[a-zA-Z0-9\s]+$/.test(trimmedTeamName)) {
       return NextResponse.json(
-        { error: 'Team name cannot contain hyphens (-) or underscores (_)' },
+        { error: 'Team name can only contain letters, numbers, and spaces' },
         { status: 400 }
       )
     }

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -4,7 +4,7 @@ import { generateUniqueSlug } from '@/lib/slugUtils'
 
 /**
  * POST /api/teams
- * Creates a new team with the provided team name, owner, and wallet addresses.
+ * Creates a new team with the provided team name and owner.
  * Validates input, generates a unique slug, and stores the team in the database.
  */
 export async function POST(request: NextRequest) {

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -15,17 +15,20 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Trim team name once for all subsequent operations
+    const trimmedTeamName = team_name.trim()
+
     // Validate team name length
-    if (team_name.trim().length === 0) {
+    if (trimmedTeamName.length === 0) {
       return NextResponse.json(
         { error: 'Team name cannot be empty' },
         { status: 400 }
       )
     }
 
-    if (team_name.length > 100) {
+    if (trimmedTeamName.length > 50) {
       return NextResponse.json(
-        { error: 'Team name must be 100 characters or less' },
+        { error: 'Team name must be 50 characters or less' },
         { status: 400 }
       )
     }
@@ -33,13 +36,13 @@ export async function POST(request: NextRequest) {
     const supabase = createSupabaseBrowserClient()
 
     // Generate unique slug from team name
-    const slug = await generateUniqueSlug(team_name.trim())
+    const slug = await generateUniqueSlug(trimmedTeamName)
 
     // Create the team
     const { data: team, error: teamError } = await supabase
       .from('teams')
       .insert({
-        team_name: team_name.trim(),
+        team_name: trimmedTeamName,
         slug,
         owner,
         wallet_addresses

--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseBrowserClient } from '@/lib/supabase'
 import { generateUniqueSlug } from '@/lib/slugUtils'
 
+/**
+ * POST /api/teams
+ * Creates a new team with the provided team name, owner, and wallet addresses.
+ * Validates input, generates a unique slug, and stores the team in the database.
+ */
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
@@ -86,6 +91,11 @@ export async function POST(request: NextRequest) {
   }
 }
 
+/**
+ * GET /api/teams
+ * Retrieves a paginated list of teams with their members.
+ * Supports limit and offset query parameters for pagination.
+ */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)

--- a/app/components/TeamForm.tsx
+++ b/app/components/TeamForm.tsx
@@ -133,7 +133,7 @@ export default function TeamForm({ mode, onSuccess, onCancel }: TeamFormProps) {
             className="w-full px-4 py-3 text-lg text-gray-900 bg-white border-2 border-gray-300 rounded-lg placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50 disabled:text-gray-500 transition-colors"
             placeholder={config.placeholder}
             disabled={loading}
-            maxLength={100}
+            maxLength={50}
           />
           
           {/* Slug Preview for Create Mode */}

--- a/app/components/TeamForm.tsx
+++ b/app/components/TeamForm.tsx
@@ -30,15 +30,26 @@ export default function TeamForm({ mode, onSuccess, onCancel }: TeamFormProps) {
   
   // Generate slug preview for create mode
   const slugPreview = useMemo(() => {
-    if (mode !== 'create' || !teamName.trim()) return '';
-    return generateSlug(teamName.trim());
+    if (mode !== 'create') return '';
+    const trimmed = teamName.trim();
+    if (!trimmed) return '';
+    return generateSlug(trimmed);
   }, [mode, teamName]);
   
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!user || !teamName.trim()) {
+    // Trim team name once for all validations and operations
+    const trimmedTeamName = teamName.trim();
+    
+    if (!user || !trimmedTeamName) {
       setError("Please enter a team name");
+      return;
+    }
+
+    // Validate team name doesn't contain hyphens or underscores
+    if (/[-_]/.test(trimmedTeamName)) {
+      setError("Team name cannot contain hyphens (-) or underscores (_)");
       return;
     }
 
@@ -54,7 +65,7 @@ export default function TeamForm({ mode, onSuccess, onCancel }: TeamFormProps) {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            team_name: teamName.trim(),
+            team_name: trimmedTeamName,
             owner: user.id,
             wallet_addresses: []
           })
@@ -78,7 +89,7 @@ export default function TeamForm({ mode, onSuccess, onCancel }: TeamFormProps) {
         const { data: team, error: teamError } = await supabase
           .from("teams")
           .select("id")
-          .ilike("team_name", teamName.trim())
+          .ilike("team_name", trimmedTeamName)
           .single();
           
         if (teamError || !team) {

--- a/app/components/TeamForm.tsx
+++ b/app/components/TeamForm.tsx
@@ -155,7 +155,7 @@ export default function TeamForm({ mode, onSuccess, onCancel }: TeamFormProps) {
           />
           
           {/* Slug Preview for Create Mode */}
-          {mode === 'create' && slugPreview && (
+          {mode === 'create' && slugPreview && !hasInvalidChars && (
             <div className="mt-3 p-4 bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-200 rounded-lg shadow-sm">
               <div className="flex items-center mb-2">
                 <svg className="w-4 h-4 text-blue-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/components/TeamForm.tsx
+++ b/app/components/TeamForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { createSupabaseBrowserClient } from "@/lib/supabase";
 import { useAuth } from "@/app/providers/AuthProvider";
 import { TEAM_FORM_CONFIG } from "@/config/teamFormConfig";
@@ -16,7 +16,15 @@ export default function TeamForm({ mode, onSuccess, onCancel }: TeamFormProps) {
   const [teamName, setTeamName] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [baseUrl, setBaseUrl] = useState(process.env.NEXT_PUBLIC_BASE_URL || '');
   const { user } = useAuth();
+
+  // Set base URL from browser location when component mounts
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setBaseUrl(window.location.origin);
+    }
+  }, []);
   
   const config = useMemo(() => TEAM_FORM_CONFIG[mode], [mode]);
   
@@ -139,7 +147,9 @@ export default function TeamForm({ mode, onSuccess, onCancel }: TeamFormProps) {
               </div>
               <div className="bg-white border border-blue-200 rounded-md p-3 font-mono text-sm shadow-inner">
                 <div className="flex items-center">
-                  <span className="text-gray-500">localhost:3000/team/</span>
+                  <span className="text-gray-500">
+                    {baseUrl || 'your-domain.com'}/team/
+                  </span>
                   <span className="font-bold text-blue-700 bg-blue-100 px-2 py-1 rounded-md ml-1 border border-blue-300">
                     {slugPreview}
                   </span>

--- a/app/team/[slug]/page.tsx
+++ b/app/team/[slug]/page.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { createSupabaseBrowserClient, Team, TeamMember, User } from '@/lib/supabase'
+
+interface TeamWithMembers extends Team {
+  members: (TeamMember & { user: User })[]
+}
+
+export default function TeamPage() {
+  const params = useParams()
+  const router = useRouter()
+  const slug = params.slug as string
+  const [team, setTeam] = useState<TeamWithMembers | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchTeamData() {
+      if (!slug) return
+
+      try {
+        const supabase = createSupabaseBrowserClient()
+
+        // Fetch team by slug
+        const { data: teamData, error: teamError } = await supabase
+          .from('teams')
+          .select('*')
+          .eq('slug', slug)
+          .single()
+
+        if (teamError) {
+          if (teamError.code === 'PGRST116') {
+            setError('Team not found')
+          } else {
+            setError('Failed to load team')
+          }
+          return
+        }
+
+        // Fetch team members with user details
+        const { data: membersData, error: membersError } = await supabase
+          .from('team_members')
+          .select(`
+            *,
+            user:users(*)
+          `)
+          .eq('team_id', teamData.id)
+          .order('role', { ascending: false }) // Show owners first
+          .order('joined_at', { ascending: true })
+
+        if (membersError) {
+          console.error('Error fetching members:', membersError)
+          setError('Failed to load team members')
+          return
+        }
+
+        setTeam({
+          ...teamData,
+          members: membersData || []
+        })
+      } catch (err) {
+        console.error('Error:', err)
+        setError('An unexpected error occurred')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchTeamData()
+  }, [slug])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading team…</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !team) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="bg-red-50 border border-red-200 rounded-lg p-6 max-w-md">
+            <h1 className="text-xl font-semibold text-red-800 mb-2">
+              {error || 'Team not found'}
+            </h1>
+            <p className="text-red-600 mb-4">
+              The team you&apos;re looking for doesn&apos;t exist or has been removed.
+            </p>
+            <button
+              onClick={() => router.push('/')}
+              className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200"
+            >
+              <svg
+                className="w-4 h-4 mr-2"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10 19l-7-7m0 0l7-7m-7 7h18"
+                />
+              </svg>
+              Back to Home
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* Back to Home Button */}
+        <button
+          onClick={() => router.push('/')}
+          className="inline-flex items-center px-4 py-2 mb-6 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 shadow-sm"
+        >
+          <svg
+            className="w-4 h-4 mr-2"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 19l-7-7m0 0l7-7m-7 7h18"
+            />
+          </svg>
+          Back to Home
+        </button>
+
+        {/* Team Header */}
+        <div className="bg-white rounded-lg shadow-sm border p-6 mb-6">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900">{team.team_name}</h1>
+            </div>
+            <div className="text-right">
+              <p className="text-sm text-gray-500">Created</p>
+              <p className="font-medium text-gray-900">
+                {new Date(team.created_at).toLocaleDateString()}
+              </p>
+            </div>
+          </div>
+
+          {/* Wallet Addresses */}
+          {team.wallet_addresses && team.wallet_addresses.length > 0 && (
+            <div className="border-t pt-4">
+              <h3 className="text-sm font-medium text-gray-700 mb-2">Team Wallets</h3>
+              <div className="flex flex-wrap gap-2">
+                {team.wallet_addresses.map((wallet, index) => (
+                  <div
+                    key={index}
+                    className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
+                  >
+                    <span className="uppercase mr-1">{wallet.chain}</span>
+                    <span className="font-mono">
+                      {wallet.address.slice(0, 6)}…{wallet.address.slice(-4)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Team Members */}
+        <div className="bg-white rounded-lg shadow-sm border">
+          <div className="px-6 py-4 border-b">
+            <h2 className="text-xl font-semibold text-gray-900">
+              Team Members ({team.members.length})
+            </h2>
+          </div>
+
+          {team.members.length === 0 ? (
+            <div className="p-6 text-center text-gray-500">
+              <p>No members found in this team.</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-gray-200">
+              {team.members.map((member) => (
+                <div key={member.id} className="p-6 flex items-center justify-between">
+                  <div className="flex items-center space-x-4">
+                    <div className="flex-shrink-0">
+                      <div className="h-10 w-10 rounded-full bg-blue-100 flex items-center justify-center">
+                        <span className="text-blue-600 font-medium text-sm">
+                          {member.user.username 
+                            ? member.user.username.charAt(0).toUpperCase()
+                            : member.user.wallet_address.slice(0, 2).toUpperCase()
+                          }
+                        </span>
+                      </div>
+                    </div>
+                    <div>
+                      <h3 className="text-sm font-medium text-gray-900">
+                        {member.user.username || 'Anonymous User'}
+                      </h3>
+                      <p className="text-sm text-gray-500 font-mono">
+                        {member.user.wallet_address.slice(0, 8)}…{member.user.wallet_address.slice(-6)}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-3">
+                    <span
+                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        member.role === 'owner'
+                          ? 'bg-purple-100 text-purple-800'
+                          : 'bg-gray-100 text-gray-800'
+                      }`}
+                    >
+                      {member.role === 'owner' ? '👑 Owner' : 'Member'}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      Joined {new Date(member.joined_at).toLocaleDateString()}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/slugUtils.ts
+++ b/lib/slugUtils.ts
@@ -23,11 +23,11 @@ export async function createUniqueSlug(
   let counter = 1
   
   while (true) {
-    // Check if slug already exists
+    // Check if slug already exists (case-insensitive)
     let query = supabase
       .from('teams')
       .select('id')
-      .eq('slug', slug)
+      .ilike('slug', slug)
     
     // Exclude current team when updating
     if (excludeId) {

--- a/lib/slugUtils.ts
+++ b/lib/slugUtils.ts
@@ -49,11 +49,6 @@ export async function createUniqueSlug(
     // Conflict found, try with counter
     slug = `${baseSlug}-${counter}`
     counter++
-    
-    // Prevent infinite loop (though very unlikely)
-    if (counter > 1000) {
-      throw new Error('Unable to generate unique slug after 1000 attempts')
-    }
   }
 }
 

--- a/lib/slugUtils.ts
+++ b/lib/slugUtils.ts
@@ -34,7 +34,7 @@ export async function createUniqueSlug(
       query = query.neq('id', excludeId)
     }
     
-    const { data, error } = await query.single()
+    const { error } = await query.single()
     
     if (error && error.code === 'PGRST116') {
       // No conflict found (PGRST116 = no rows returned), slug is available

--- a/lib/slugUtils.ts
+++ b/lib/slugUtils.ts
@@ -1,0 +1,66 @@
+import { createSupabaseBrowserClient } from './supabase'
+
+/**
+ * Generate a URL-friendly slug from a team name
+ */
+export function generateSlug(teamName: string): string {
+  return teamName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') // Remove leading/trailing hyphens
+}
+
+/**
+ * Create a unique slug by checking for conflicts and adding a counter if needed
+ */
+export async function createUniqueSlug(
+  baseSlug: string, 
+  excludeId?: string
+): Promise<string> {
+  const supabase = createSupabaseBrowserClient()
+  let slug = baseSlug
+  let counter = 1
+  
+  while (true) {
+    // Check if slug already exists
+    let query = supabase
+      .from('teams')
+      .select('id')
+      .eq('slug', slug)
+    
+    // Exclude current team when updating
+    if (excludeId) {
+      query = query.neq('id', excludeId)
+    }
+    
+    const { data, error } = await query.single()
+    
+    if (error && error.code === 'PGRST116') {
+      // No conflict found (PGRST116 = no rows returned), slug is available
+      return slug
+    }
+    
+    if (error) {
+      // Some other error occurred
+      throw new Error(`Error checking slug uniqueness: ${error.message}`)
+    }
+    
+    // Conflict found, try with counter
+    slug = `${baseSlug}-${counter}`
+    counter++
+    
+    // Prevent infinite loop (though very unlikely)
+    if (counter > 1000) {
+      throw new Error('Unable to generate unique slug after 1000 attempts')
+    }
+  }
+}
+
+/**
+ * Generate a unique slug from a team name
+ */
+export async function generateUniqueSlug(teamName: string, excludeId?: string): Promise<string> {
+  const baseSlug = generateSlug(teamName)
+  return await createUniqueSlug(baseSlug, excludeId)
+}

--- a/lib/slugUtils.ts
+++ b/lib/slugUtils.ts
@@ -7,7 +7,8 @@ export function generateSlug(teamName: string): string {
   return teamName
     .trim()
     .toLowerCase()
-    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/'/g, '') // Remove apostrophes (e.g., "kyle's" -> "kyles")
+    .replace(/[^a-zA-Z0-9]+/g, '-') // Replace other special chars with hyphens
     .replace(/^-+|-+$/g, '') // Remove leading/trailing hyphens
 }
 

--- a/lib/slugUtils.ts
+++ b/lib/slugUtils.ts
@@ -7,8 +7,7 @@ export function generateSlug(teamName: string): string {
   return teamName
     .trim()
     .toLowerCase()
-    .replace(/'/g, '') // Remove apostrophes (e.g., "kyle's" -> "kyles")
-    .replace(/[^a-zA-Z0-9]+/g, '-') // Replace other special chars with hyphens
+    .replace(/[^a-zA-Z0-9]+/g, '-') // Replace spaces and special chars with hyphens
     .replace(/^-+|-+$/g, '') // Remove leading/trailing hyphens
 }
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -25,6 +25,7 @@ export interface User {
 export interface Team {
   id: string
   team_name: string
+  slug: string
   wallet_addresses?: WalletAddress[]
   owner: string
   created_at: string

--- a/migrations/002_create_teams_table.sql
+++ b/migrations/002_create_teams_table.sql
@@ -69,32 +69,6 @@ CREATE TRIGGER update_teams_updated_at
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
 
--- Function to generate slug from team name
-CREATE OR REPLACE FUNCTION generate_slug(team_name_input TEXT)
-RETURNS TEXT AS $$
-BEGIN
-    -- Convert to lowercase, replace spaces/special chars with hyphens, trim extra hyphens
-    RETURN trim(both '-' from lower(regexp_replace(trim(team_name_input), '[^a-zA-Z0-9]+', '-', 'g')));
-END;
-$$ LANGUAGE plpgsql;
-
--- Function for trigger to auto-generate slug
-CREATE OR REPLACE FUNCTION set_slug()
-RETURNS TRIGGER AS $$
-BEGIN
-    -- Only generate slug if not provided or empty
-    IF NEW.slug IS NULL OR trim(NEW.slug) = '' THEN
-        NEW.slug = generate_slug(NEW.team_name);
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
--- Trigger to auto-generate slug before insert/update
-CREATE TRIGGER generate_team_slug_trigger
-    BEFORE INSERT OR UPDATE ON teams
-    FOR EACH ROW
-    EXECUTE FUNCTION set_slug();
 
 -- Function to automatically add team owner to team_members
 CREATE OR REPLACE FUNCTION add_team_owner_as_member()

--- a/migrations/002_create_teams_table.sql
+++ b/migrations/002_create_teams_table.sql
@@ -65,7 +65,6 @@ CREATE TRIGGER update_teams_updated_at
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
 
-
 -- Function to automatically add team owner to team_members
 CREATE OR REPLACE FUNCTION add_team_owner_as_member()
 RETURNS TRIGGER AS $$

--- a/migrations/002_create_teams_table.sql
+++ b/migrations/002_create_teams_table.sql
@@ -2,7 +2,6 @@
 CREATE TABLE IF NOT EXISTS teams (
     id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
     team_name TEXT UNIQUE NOT NULL,
-    slug TEXT UNIQUE NOT NULL,
     wallet_addresses JSONB DEFAULT '[]'::jsonb,
     owner UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
@@ -11,9 +10,6 @@ CREATE TABLE IF NOT EXISTS teams (
 
 -- Create index on team_name for faster lookups
 CREATE INDEX IF NOT EXISTS idx_teams_team_name ON teams(team_name);
-
--- Create index on slug for faster lookups
-CREATE INDEX IF NOT EXISTS idx_teams_slug ON teams(slug);
 
 -- Create GIN index on wallet_addresses JSONB for faster lookups
 CREATE INDEX IF NOT EXISTS idx_teams_wallet_addresses ON teams USING GIN (wallet_addresses);

--- a/migrations/003_add_team_slugs.sql
+++ b/migrations/003_add_team_slugs.sql
@@ -1,0 +1,9 @@
+-- Add slug functionality to teams table
+-- This migration adds the slug column for team URL routing
+-- Slug generation is handled by the API route, not the database
+
+-- Add slug column to teams table
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS slug TEXT UNIQUE NOT NULL;
+
+-- Create index on slug for faster lookups
+CREATE INDEX IF NOT EXISTS idx_teams_slug ON teams(slug);


### PR DESCRIPTION
**Overview**
- Auto-generated URL-friendly slugs from team names (e.g., "My Awesome Team" → "my-awesome-team")
- Edited team schema to include slug
- New `/team/[slug]` routes to view team details and members
- Restrict team names to alphanumeric characters and spaces only to avoid future conflicts
- Add real-time validation warnings for invalid characters
- Disable submit button when form is invalid
- Add case-insensitive slug uniqueness checking
- Shows all team members with information of them joining

**Deployment Steps**
- Run 003_add_team_slugs.sql migration before deploying application code

